### PR TITLE
fix(template): removed deprecated import

### DIFF
--- a/template/nuxt.config.ts
+++ b/template/nuxt.config.ts
@@ -1,4 +1,4 @@
-import { defineNuxtConfig } from 'nuxt'
+import { defineNuxtConfig } from 'nuxt/config'
 
 export default defineNuxtConfig({
   extends: 'my-nuxt-theme'

--- a/theme/nuxt.config.ts
+++ b/theme/nuxt.config.ts
@@ -1,4 +1,4 @@
-import { defineNuxtConfig } from 'nuxt'
+import { defineNuxtConfig } from 'nuxt/config'
 
 // https://v3.nuxtjs.org/api/configuration/nuxt.config
 export default defineNuxtConfig({


### PR DESCRIPTION
The `defineNuxtConfig` import from `nuxt` was deprecated in RC.10

https://github.com/nuxt/framework/releases/tag/v3.0.0-rc.10